### PR TITLE
[ Fix ] API012 소속팀 개인프로필 수정 - 이미지 파일 전송하지 않아도 그외 정보를 수정 완료 (@ModelAtt…

### DIFF
--- a/src/main/java/com/threeNerds/basketballDiary/mvc/myTeam/controller/MyTeamController.java
+++ b/src/main/java/com/threeNerds/basketballDiary/mvc/myTeam/controller/MyTeamController.java
@@ -279,14 +279,16 @@ public class MyTeamController {
     public ResponseEntity<?> modifyMyTeamsProfile(
             @SessionAttribute(value = LOGIN_USER, required = false) SessionUser userSession,
             @PathVariable Long teamSeq,
-            @ModelAttribute ModifyMyTeamProfileRequest reqBody
+//            @ModelAttribute ModifyMyTeamProfileRequest reqBody
+            @RequestParam(required = false) String backNumber,
+            @RequestParam(required = false) MultipartFile imageFile
     ) {
         teamMemberService.modifyMyTeamProfile(
             new ModifyMyTeamProfileRequest(
                     userSession.getUserSeq()
                   , teamSeq
-                  , reqBody.getBackNumber()
-                  , reqBody.getImageFile()
+                  , backNumber
+                  , imageFile
             )
         );
         return RESPONSE_OK;

--- a/src/main/java/com/threeNerds/basketballDiary/mvc/myTeam/dto/modifyMyTeamProfile/request/ModifyMyTeamProfileRequest.java
+++ b/src/main/java/com/threeNerds/basketballDiary/mvc/myTeam/dto/modifyMyTeamProfile/request/ModifyMyTeamProfileRequest.java
@@ -10,6 +10,7 @@ public class ModifyMyTeamProfileRequest {
     private Long userSeq;
     private Long teamSeq;
     private String backNumber;
+    @Nullable
     private MultipartFile imageFile;
 
     public ModifyMyTeamProfileRequest( Long userSeq, Long teamSeq, String backNumber, MultipartFile imageFile ) {


### PR DESCRIPTION
…ribute 걷어내고, @RequestParam으로 대체 >> @ModelAttribute는 모델에 대한 관리가 주용도이며, 해당 어노테이션 선언된 타입의 필드에 null이 들어올 경우 무조건 String[]이 매핑되어 데이터 바인딩시 오류가 발생할 수 있음 )